### PR TITLE
Remove outdated info about Scratch and LLK from i18n files (#54)

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -60,7 +60,6 @@
 	"scratchwikiskin-footer-scratchday": "Scratch Day",
 	"scratchwikiskin-footer-conference": "Scratch Konferenz",
 	"scratchwikiskin-footer-foundation": "Scratch Stiftung",
-	"scratchwikiskin-footer-llk": "Scratch ist ein Projekt der Lifelong Kindergarten Group am MIT Media Lab",
 	"scratchwikiskin-notloggedin": "nicht angemeldet",
 	"scratchwikiskin-pref-color": "Kopfbalken Farbe:",
 	"scratchwikiskin-search": "Suche im Wiki"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -59,7 +59,6 @@
 	"scratchwikiskin-footer-scratchday": "Scratch Day",
 	"scratchwikiskin-footer-conference": "Scratch Conference",
 	"scratchwikiskin-footer-foundation": "Scratch Foundation",
-	"scratchwikiskin-footer-llk": "Scratch is a project of the Lifelong Kindergarten Group at the MIT Media Lab",
 	"scratchwikiskin-notloggedin": "Not logged in",
 	"scratchwikiskin-pref-color": "Header color:",
 	"scratchwikiskin-search": "Search the Wiki"

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -59,7 +59,6 @@
 	"scratchwikiskin-footer-scratchday": "Jour de Scratch",
 	"scratchwikiskin-footer-conference": "Conf\u00e9rences Scratch",
 	"scratchwikiskin-footer-foundation": "Fondation Scratch",
-	"scratchwikiskin-footer-llk": "Scratch est un projet du Lifelong Kindergarten Group au sein du MIT Media Lab",
 	"scratchwikiskin-notloggedin": "Pas connect\u00e9",
 	"scratchwikiskin-pref-color": "Couleur de l'en-t\u00eate:",
 	"scratchwikiskin-search": "Rechercher dans le Wiki"

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -59,7 +59,6 @@
 	"scratchwikiskin-footer-scratchday": "Hari Scratch",
 	"scratchwikiskin-footer-conference": "Konferensi Scratch",
 	"scratchwikiskin-footer-foundation": "Lembaga Scratch",
-	"scratchwikiskin-footer-llk": "Scratch adalah sebuah proyek dari Lifelong Kindergarten Group di MIT Media Lab",
 	"scratchwikiskin-notloggedin": "Tidak sedang masuk",
 	"scratchwikiskin-pref-color": "Warna Bagian Atas",
 	"scratchwikiskin-search": "Cari di wiki"

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -61,7 +61,6 @@
 	"scratchwikiskin-footer-conference": "Scratchカンファレンス",
 	"scratchwikiskin-footer-foundation": "Scratch財団",
 	"scratchwikiskin-footer-scratchsite": "Scratchウェブサイト",
-	"scratchwikiskin-footer-llk": "ScratchはMITメディアラボ ライフロングキンダーガーテングループのプロジェクトです。",
 	"scratchwikiskin-notloggedin": "未ログイン",
 	"scratchwikiskin-pref-color":"ヘッダーの色",
 	"scratchwikiskin-search": "検索"

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -59,7 +59,6 @@
 	"scratchwikiskin-footer-scratchday": "Scratch Day",
 	"scratchwikiskin-footer-conference": "Scratch-Conferentie",
 	"scratchwikiskin-footer-foundation": "Scratch Foundation",
-	"scratchwikiskin-footer-llk": "Scratch is een project van de Lifelong Kindergarten Group van het MIT Media Lab",
 	"scratchwikiskin-notloggedin": "Niet Ingelogd",
 	"scratchwikiskin-pref-color": "Header's kleur:",
 	"scratchwikiskin-search": "Zoeken op de Wiki"

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -59,7 +59,6 @@
 	"scratchwikiskin-footer-scratchday": "Scratch Day link in footer",
 	"scratchwikiskin-footer-conference": "Scratch Conference link in footer",
 	"scratchwikiskin-footer-foundation": "Scratch Foundation link in footer",
-	"scratchwikiskin-footer-llk": "Disclaimer that Scratch is by MIT LLK",
 	"scratchwikiskin-notloggedin": "Text for username when not logged in",
 	"scratchwikiskin-pref-color": "Prompt to set header color",
 	"scratchwikiskin-search": "Placeholder for search box"

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -55,7 +55,6 @@
 	"scratchwikiskin-footer-scratchday": "Scratch Day",
 	"scratchwikiskin-footer-conference": "\u041a\u043e\u043d\u0444\u0435\u0440\u0435\u043d\u0446\u0438\u044f \u0421\u043a\u0440\u0435\u0442\u0447",
 	"scratchwikiskin-footer-foundation": "\u0424\u043e\u043d\u0434 \u0421\u043a\u0440\u0435\u0442\u0447",
-	"scratchwikiskin-footer-llk": "\u0421\u043a\u0440\u0435\u0442\u0447 \u044d\u0442\u043e \u043f\u0440\u043e\u0435\u043a\u0442 \u0433\u0440\u0443\u043f\u043f\u044b Lifelong Kindergarten \u0432 MIT Media Lab",
 	"scratchwikiskin-notloggedin":"\u041d\u0435 \u0432\u043e\u0448\u0435\u043b",
 	"scratchwikiskin-pref-color": "\u0426\u0432\u0435\u0442 \u0437\u0430\u0433\u043e\u043b\u043e\u0432\u043a\u0430:",
 	"scratchwikiskin-search": "\u041f\u043e\u0438\u0441\u043a \u0432 \u0412\u0438\u043a\u0438"

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -59,7 +59,6 @@
 	"scratchwikiskin-footer-scratchday": "Scratch Günü",
 	"scratchwikiskin-footer-conference": "Scratch Konferansı",
 	"scratchwikiskin-footer-foundation": "Scratch Kuruluşu",
-	"scratchwikiskin-footer-llk": "Scratch, MIT Medya Lab'ında yer alan Lifelong Kindergarten grubunun bir projesidir",
 	"scratchwikiskin-notloggedin": "Giriş yapılmadı",
 	"scratchwikiskin-pref-color": "Başlık rengi:",
 	"scratchwikiskin-search": "Viki'de arat"

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -56,7 +56,6 @@
 	"scratchwikiskin-footer-scratchday": "Scratch Day",
 	"scratchwikiskin-footer-conference": "Scratch 会议",
 	"scratchwikiskin-footer-foundation": "Scratch 基金会",
-	"scratchwikiskin-footer-llk": "Scratch 是麻省理工学院终生幼儿园团队底下的一个计划",
 	"scratchwikiskin-notloggedin": "未登入",
 	"scratchwikiskin-pref-color": "页定颜色：",
 	"scratchwikiskin-search": "搜寻维基"

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -56,7 +56,6 @@
 	"scratchwikiskin-footer-scratchday": "Scratch Day",
 	"scratchwikiskin-footer-conference": "Scratch 會議",
 	"scratchwikiskin-footer-foundation": "Scratch 基金會",
-	"scratchwikiskin-footer-llk": "Scratch 是麻省理工學院終生幼兒園團隊底下的一個計畫",
 	"scratchwikiskin-notloggedin": "未登入",
 	"scratchwikiskin-pref-color": "頁定顏色：",
 	"scratchwikiskin-search": "搜尋維基"


### PR DESCRIPTION
Scratch is no longer a project of LLK and nor the wiksi neither Scratch has this part about LLK in their footers.